### PR TITLE
Allow veewee/xml ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-soap/xml": "^1.4",
         "php-http/client-common": "^2.3",
         "robrichards/wse-php": "^2.0",
-        "veewee/xml": "^2.2"
+        "veewee/xml": "^2.2||^3.0"
     },
     "require-dev": {
         "nyholm/psr7": "^1.5",


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #16

#### Summary

I couldn't test the change in my real-world example yet, so testing is appreciated. However, I did verify that the unit tests can still be executed successfully with version 3.x of `veewee/xml`.