### PR TITLE
Allow modification of encryptSignature

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ $wsseMiddleware = new WsseMiddleware(
         ))
             ->withKeyEncryptionMethod(KeyEncryptionMethod::RSA_OAEP_MGF1P)
             ->withDataEncryptionMethod(DataEncryptionMethod::AES256_CBC)
+            
+            //Per Default the Signature gets Encrypted too. To Disable Encryption of the Signature you can add the following. 
+            ->withEncryptSignature(false)
     ],
     incoming: [
         new Entry\Decryption($privKey)

--- a/src/WSSecurity/Entry/Encryption.php
+++ b/src/WSSecurity/Entry/Encryption.php
@@ -61,7 +61,7 @@ final class Encryption implements WsseEntry
         $encryptionKey->passphrase = $this->key->passphrase();
         $encryptionKey->loadKey($this->key->contents(), false, $this->key->isCertificate());
 
-        $wsse->encryptSoapDoc($encryptionKey, $dataEncryptionKey,encryptSignature:$this->encryptSignature);
+        $wsse->encryptSoapDoc($encryptionKey, $dataEncryptionKey, encryptSignature:$this->encryptSignature);
 
         $encryptedKey = (new EncryptedKeyLocator())($envelope);
         ($this->keyIdentifier)($envelope, $wsse, $encryptedKey);


### PR DESCRIPTION
Allows the modifcation of the encryptSignature Parameter of the WSSESOAP::encryptSoapDoc method

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

<!-- Provide a summary of your change. -->
I added the possibility to modify the encryptSignature Parameter of  encryptSoapDoc Method from wse-php
As one of my Projects don't want the signature encrypted for reasons.

Please feel free to tell me if I need to do / change something
